### PR TITLE
Removes legacy dot syntax for dojo modules

### DIFF
--- a/JOS.PropertyKeyValueList/KeyValueEditorDescriptor.cs
+++ b/JOS.PropertyKeyValueList/KeyValueEditorDescriptor.cs
@@ -11,7 +11,7 @@ namespace JOS.PropertyKeyValueList
 		{
 		public KeyValueEditorDescriptor() 
 		{
-			ClientEditingClass = "keyvaluelist.scripts.KeyValueList";
+			ClientEditingClass = "keyvaluelist/scripts/KeyValueList";
 		}
 
 		protected override void SetEditorConfiguration(ExtendedMetadata metadata) 


### PR DESCRIPTION
Hi Josef,

After upgrading a project to EPiServer 10, I found that your package was unfortunately incompatible.  
The issue is described in EPiServer [release note CMS-2295](http://world.episerver.com/documentation/Release-Notes/ReleaseNote/?releaseNoteId=CMS-2295). 

Please also update the package on nuget.org 😃 
