### PR TITLE
Template not being rendered in EPi10 when creating blocks.

### DIFF
--- a/JOS.PropertyKeyValueList/ClientResources/KeyValueList/Scripts/KeyValueList.js
+++ b/JOS.PropertyKeyValueList/ClientResources/KeyValueList/Scripts/KeyValueList.js
@@ -223,6 +223,11 @@
 			},
 			//This gets called on startup by EPI if value != null.
 			_setValueAttr: function (value) {
+				// EPi does send null values, so return if it is...
+				if (value === null) {
+					return;
+				}
+				
 				this._setValue(value);
 				if (this.readOnlyKeysMode) {
 					this._placeValues();


### PR DESCRIPTION
Just noticed that there is a template problem in EPi10 when using the property inside a block.

When creating a new block containing the property, the edit template is not rendered. You must first create the block, then edit it, to be able to add key value items. This fix makes the template render as soon as block is being created. 